### PR TITLE
checkbox de devoluciones en pedidos (vista tree) 

### DIFF
--- a/point_of_sale.py
+++ b/point_of_sale.py
@@ -17,6 +17,7 @@ class pos_order(osv.osv):
         'pedido_original' : fields.many2one('pos.order', 'Pedido original'),
         'numero_factura' : fields.char('Numero de factura a generar'),
         'anulado' : fields.boolean('Anulado'),
+        'devuelto': fields.boolean('Devuelto'),
         'sale_manual_journal': fields.related('session_id', 'config_id', 'journal_manual_id', relation='account.journal', type='many2one', string='Diario de ventas manual', store=True, readonly=True),
     }
 

--- a/point_of_sale_view.xml
+++ b/point_of_sale_view.xml
@@ -85,6 +85,7 @@
                 <data>
                     <field name="name" position="after">
                         <field name="anulado"/>
+                        <field name="devuelto"/>
                     </field>
                 </data>
             </field>

--- a/wizard/anulacion_devolucion.py
+++ b/wizard/anulacion_devolucion.py
@@ -110,7 +110,7 @@ class pos_distefano_anulacion_devolucion(osv.osv_memory):
                         'qty': -1 * l.cantidad,
                         'price_unit': l.linea.product_id.list_price
                     }, context=context)
-                    self.pool.get('pos.order.line').write(cr, uid, l.linea.id, {'devuelto': True}, context=context)
+                    self.pool.get('pos.order').write(cr, uid, d.pedido.id, {'devuelto': True}, context=context)
 
                 abs = {
                     'name': _('Return Products'),
@@ -128,7 +128,7 @@ class pos_distefano_anulacion_devolucion(osv.osv_memory):
 
     _columns = {
         'pedido': fields.many2one('pos.order', 'Pedido', required=True),
-        'tipo': fields.selection([('anular', 'Anular'), ('devolver', 'Devoler')], 'Operacion', required=True),
+        'tipo': fields.selection([('anular', 'Anular'), ('devolver', 'Devolver')], 'Operacion', required=True),
         'lineas': fields.one2many('pos_distefano.anulacion_devolucion.linea', 'anulacion_devolucion', 'Lineas'),
     }
 

--- a/wizard/anulacion_devolucion.py
+++ b/wizard/anulacion_devolucion.py
@@ -110,6 +110,7 @@ class pos_distefano_anulacion_devolucion(osv.osv_memory):
                         'qty': -1 * l.cantidad,
                         'price_unit': l.linea.product_id.list_price
                     }, context=context)
+                    self.pool.get('pos.order.line').write(cr, uid, l.linea.id, {'devuelto': True}, context=context)
                     self.pool.get('pos.order').write(cr, uid, d.pedido.id, {'devuelto': True}, context=context)
 
                 abs = {


### PR DESCRIPTION
Cambios para el control de los pedidos que se han hecho una devolucion; es un checkbox que se utiliza para aplicarlo en la vista tree de pedidos en terminal punto de venta.